### PR TITLE
setup show/hide routes at module start and convert to express v5 paths

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -12,12 +12,12 @@ module.exports = NodeHelper.create({
 		console.log("Starting module: " + this.name);
 
 		var self = this;
-		this.expressApp.get('/motioneye/hide/:id*?', function (req, res) {
+		this.expressApp.get('/motioneye/hide/{:id}', function (req, res) {
 			console.log("Hide registered: " + req.params.id);
 			res.send('Hide registered: ' + req.params.id);
 			self.sendSocketNotification("MotionEyeHide", req.params.id);
 		});
-		this.expressApp.get('/motioneye/:id*?', function (req, res) {
+		this.expressApp.get('/motioneye/{:id}', function (req, res) {
 			console.log("Motion registered: " + req.params.id);
 			res.send('Motion registered: ' + req.params.id);
 			self.sendSocketNotification("MotionEyeShow", req.params.id);

--- a/node_helper.js
+++ b/node_helper.js
@@ -10,27 +10,27 @@ var NodeHelper = require("node_helper");
 module.exports = NodeHelper.create({
 	start: function() {
 		console.log("Starting module: " + this.name);
+
+		var self = this;
+		this.expressApp.get('/motioneye/hide/:id*?', function (req, res) {
+			console.log("Hide registered: " + req.params.id);
+			res.send('Hide registered: ' + req.params.id);
+			self.sendSocketNotification("MotionEyeHide", req.params.id);
+		});
+		this.expressApp.get('/motioneye/:id*?', function (req, res) {
+			console.log("Motion registered: " + req.params.id);
+			res.send('Motion registered: ' + req.params.id);
+			self.sendSocketNotification("MotionEyeShow", req.params.id);
+		});
 	},
 
 	socketNotificationReceived: function(notification, config) {
 		if (notification === "CONFIG") {
+			console.log("started configuring the node helper of " + this.name);
 			if (config.autoHide) {
-				var self = this;
-				
 				console.log("Hiding camera: " + config.id);
 				this.sendSocketNotification("MotionEyeHide", config.id);
-
-				this.expressApp.get('/motioneye/hide/:id*?', function (req, res) {
-					console.log("Hide registered: " + req.params.id);
-					res.send('Hide registered: ' + req.params.id);
-					self.sendSocketNotification("MotionEyeHide", req.params.id);
-				});
-				this.expressApp.get('/motioneye/:id*?', function (req, res) {
-					console.log("Motion registered: " + req.params.id);
-					res.send('Motion registered: ' + req.params.id);
-					self.sendSocketNotification("MotionEyeShow", req.params.id);
-				});
-			} 
+			}
 
 			return;
 		}


### PR DESCRIPTION
This changes the node_helper to register the routes to show and hide instances to register during the start, instead of setting them up later.

Also MagicMirror² switched to express v5 now, so the path syntax had to be changed, so it keeps working.